### PR TITLE
Respond to command by thread

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -83,10 +83,11 @@ type Command struct {
 	Type     CommandType
 	Target   CommandTarget
 	Mentions []string
+	ThreadId string
 }
 
 // ParseCommand takes care of turning a  text string into a proper command
-func ParseCommand(commandStr string) (*Command, error) {
+func ParseCommand(commandStr string, threadId string) (*Command, error) {
 	trimmedCommand := strings.Trim(strings.ToLower(string(commandStr)), trimSymbols)
 	parts := strings.Split(trimmedCommand, " ")
 
@@ -128,5 +129,5 @@ func ParseCommand(commandStr string) (*Command, error) {
 			}
 		}
 	}
-	return &Command{Mentions: mentions, Type: commandType, Target: commandTarget}, nil
+	return &Command{Mentions: mentions, Type: commandType, Target: commandTarget, ThreadId: threadId}, nil
 }


### PR DESCRIPTION
Now we include the `thread_id` on our responses to commands so that the command and the response belong to the same thread.
